### PR TITLE
Added the MyAnimeList ID to the Anime and Manga classes and GraphQL requests.

### DIFF
--- a/anilist/client_process.py
+++ b/anilist/client_process.py
@@ -21,6 +21,7 @@ from .types import (
 def construct_manga_object(media) -> Manga:
     manga = Manga(
         id=media["id"],
+        idmal=media["idMal"],
         title=media["title"],
         url=media["siteUrl"],
         chapters=media["chapters"],
@@ -72,6 +73,7 @@ def construct_manga_object(media) -> Manga:
 def construct_anime_object(media: dict) -> Anime:
     anime = Anime(
         id=media["id"],
+        idmal=media["idMal"],
         title=media["title"],
         url=media["siteUrl"],
         episodes=media["episodes"],
@@ -270,6 +272,7 @@ def process_get_anime(data) -> Optional[Anime]:
             item = data["data"]["Page"]["media"][0]
             return Anime(
                 id=item["id"],
+                idmal=item["idMal"],
                 title=item["title"],
                 url=item["siteUrl"],
                 episodes=item["episodes"],
@@ -327,6 +330,7 @@ def process_get_manga(data) -> Optional[Manga]:
             item = data["data"]["Page"]["media"][0]
             return Manga(
                 id=item["id"],
+                idmal=item["idMal"],
                 title=item["title"],
                 url=item["siteUrl"],
                 chapters=item["chapters"],

--- a/anilist/queries/_query_files/get/anime_get.graphql
+++ b/anilist/queries/_query_files/get/anime_get.graphql
@@ -5,6 +5,7 @@ query($id: Int) {
     Page(page: 1, perPage: 1) {
         media(id: $id, type: ANIME) {
             id
+            idMal
             title {
                 romaji
                 english
@@ -102,6 +103,7 @@ query($id: Int) {
                 edges {
                     node {
                         id
+                        idMal
                         title {
                             romaji
                             english

--- a/anilist/queries/_query_files/get/character_get.graphql
+++ b/anilist/queries/_query_files/get/character_get.graphql
@@ -26,6 +26,7 @@ query($id: Int) {
                         native
                     }
                     id
+                    idMal
                     type
                 }
             }

--- a/anilist/queries/_query_files/get/list_get.graphql
+++ b/anilist/queries/_query_files/get/list_get.graphql
@@ -25,6 +25,7 @@ query ($user_id: Int, $page: Int = 1, $per_page: Int = 25) {
             media {
                 type
                 id
+                idMal
                 title {
                     romaji
                     english
@@ -143,6 +144,7 @@ query ($user_id: Int, $page: Int = 1, $per_page: Int = 25) {
             media {
                 type
                 id
+                idMal
                 title {
                     romaji
                     english

--- a/anilist/queries/_query_files/get/list_get_anime.graphql
+++ b/anilist/queries/_query_files/get/list_get_anime.graphql
@@ -30,6 +30,7 @@ query ($user_id: Int, $page: Int = 1, $per_page: Int = 25) {
             media {
                 type
                 id
+                idMal
                 title {
                     romaji
                     english

--- a/anilist/queries/_query_files/get/list_get_manga.graphql
+++ b/anilist/queries/_query_files/get/list_get_manga.graphql
@@ -30,6 +30,7 @@ query ($user_id: Int, $page: Int = 1, $per_page: Int = 25) {
             media {
                 type
                 id
+                idMal
                 title {
                     romaji
                     english

--- a/anilist/queries/_query_files/get/manga_get.graphql
+++ b/anilist/queries/_query_files/get/manga_get.graphql
@@ -5,6 +5,7 @@ query($id: Int) {
     Page(page: 1, perPage: 1) {
         media(id: $id, type: MANGA) {
             id
+            idMal
             title {
                 romaji
                 english
@@ -101,6 +102,7 @@ query($id: Int) {
                 edges {
                     node {
                         id
+                        idMal
                         title {
                             romaji
                             english

--- a/anilist/queries/_query_files/get/user_get.graphql
+++ b/anilist/queries/_query_files/get/user_get.graphql
@@ -15,6 +15,7 @@ query ($name: String) {
             anime {
                 nodes {
                     id
+                    idMal
                     title {
                         romaji
                         english
@@ -39,6 +40,7 @@ query ($name: String) {
             manga {
                 nodes {
                     id
+                    idMal
                     title {
                         romaji
                         english

--- a/anilist/types/anime.py
+++ b/anilist/types/anime.py
@@ -27,6 +27,7 @@ class Anime(Hashable):
         id: int,
         title: Dict,
         url: str,
+        idmal: int = None,
         episodes: int = None,
         description: str = None,
         format: str = None,
@@ -58,6 +59,8 @@ class Anime(Hashable):
         self.title = Title(
             romaji=title["romaji"], english=title["english"], native=title["native"]
         )
+        if idmal:
+            self.idmal = idmal
         if url:
             self.url = url
         if episodes:

--- a/anilist/types/manga.py
+++ b/anilist/types/manga.py
@@ -27,6 +27,7 @@ class Manga(Hashable):
         id: int,
         title: Dict,
         url: str,
+        idmal: int = None,
         chapters: int = None,
         description: str = None,
         status: str = None,
@@ -57,6 +58,8 @@ class Manga(Hashable):
         self.title = Title(
             romaji=title["romaji"], english=title["english"], native=title["native"]
         )
+        if idmal:
+            self.idmal = idmal
         if url:
             self.url = url
         if chapters:


### PR DESCRIPTION
Hi!

First of all nice work rewriting the project! I was going to open a PR to the original repo, but since you did some major changes and it seems It's going to take a while to merge them i decided to PR here :)

I added the field "idMal" from the Anilist API to both Media objects (Anime and Manga), which corresponds to the ID of any given Media object on the [MyAnimeList](https://myanimelist.net) website.

Having access to the MAL ID is specially useful for data analysis and machine learning, as there are a lot of datasets that list each anime by It's MAL ID ([Here's the one i was working with, as an example](https://www.kaggle.com/datasets/hernan4444/anime-recommendation-database-2020)).

Thank you for your work and have a nice day!